### PR TITLE
add charter template

### DIFF
--- a/Charter/OM-Charter-WG_Name.md
+++ b/Charter/OM-Charter-WG_Name.md
@@ -1,0 +1,52 @@
+## IoT Connectivity Working Group Chapter
+
+This Working Group Charter establishes the Scope and intellectual property terms used to develop the materials identified 
+in this Working Group Charter for the Project. Only Project Steering Members, Associates, and Contributors that Joined the 
+Working Group will be bound by its terms and be permitted to participate in this Working Group.
+
+1. **Working Group Name**. **Working Group**
+2. **Working Group Scope**. <scope>
+
+
+
+## Approach and Work Packages
+<description>
+
+3. **Copyright Policy**. Each Working Group must specify the copyright mode under which it will operate prior to 
+initiating any work on any Draft Deliverable or Approved Deliverable other than source code. The copyright mode for 
+this Working Group is: _**[Check one box]**_
+
+     - [ ] **Copyright Grant to Project**, as set forth in Appendix A, Copyright Policy Option 1.
+     - [ ] **Creative Commons Attribution 4.0**, as set forth in Appendix A, Copyright Policy Option 2.
+     - [ ] **Open Web Foundation 1.0.** (only for those Working Groups selecting the Open Web Foundation mode for patent 
+     licensing).
+     
+4. **Approved Deliverable Patent Licensing**. Each Working Group must specify the patent mode under which it will operate prior to initiating any work on any Draft Deliverable or Approved Deliverable other than source code. The patent mode for this Working Group is: _**[Check one box]**_
+
+     - [ ] **RAND Royalty-Free Mode**, as set forth in Appendix A, Patent Policy Option 1.
+     - [ ] **International Mode**, as set forth in Appendix A, Patent Policy Option 2.
+     - [ ] **Open Web Foundation Agreement 1.0 Mode**, as set forth in Appendix A, Patent Policy Option 3.
+     - [ ] **W3C Mode**, as set forth in Appendix A, Patent Policy Option 4.
+     - [ ] **No Patent License**. No patent licenses are granted for the Draft Deliverables or Approved Deliverables 
+     developed by this Working Group.
+
+The assurances provided in the selected patent mode are binding on the Working Group Participant’s successors-in-interest. 
+In addition, each Working Group Participant will include in any documents transferring ownership of patents subject to 
+the assurance provisions sufficient to ensure that the commitments in the assurance are binding on the transferee, 
+and that the transferee will similarly include appropriate provisions in the event of future transfers with the goal of 
+binding each successor-in-interest.
+
+5. **Source Code**. Working Group Participants contributing source code to this Working Group agree that those source 
+code contributions are subject to the Developer Certificate of Origin version 1.1, available at 
+http://developercertificate.org/, and the license indicated below. Source code may not be a required element of an 
+Approved Deliverable specification. _**[Check one box]**_
+
+     - [ ] **Apache 2.0**, available at http://www.apache.org/licenses/LICENSE-2.0.html. 
+     - [ ] **MIT License**, available at https://opensource.org/licenses/MIT.
+     - [ ] **Mozilla Public License 2.0**, available at https://www.mozilla.org/MPL/2.0/. 
+     - [ ] Other_________________________________
+     - [ ] No source code will be developed.
+
+6. **Non-Working Group Participant Feedback and Participation**. Upon the Approval of the Working Group Participants, 
+the Working Group can request feedback from and/or allow Non-Working Group Participant participation in a Working Group, 
+subject to each Non-Working Group Participant executing the Feedback Agreement set forth in **Appendix B**.

--- a/Charter/OM-Charter-WG_Name.md
+++ b/Charter/OM-Charter-WG_Name.md
@@ -1,4 +1,4 @@
-## IoT Connectivity Working Group Chapter
+## <WG Name> Working Group Chapter
 
 This Working Group Charter establishes the Scope and intellectual property terms used to develop the materials identified 
 in this Working Group Charter for the Project. Only Project Steering Members, Associates, and Contributors that Joined the 


### PR DESCRIPTION
Does anyone knows if we do have a template for the WG charter? So far the only document that I have seen is the one from IoT-Connectivity which has been already customized.