### PR TITLE
add a new static conformance requirements table

### DIFF
--- a/TS/OMP-Technical-Specification.md
+++ b/TS/OMP-Technical-Specification.md
@@ -233,3 +233,48 @@ Sections for the normative specification text. Fill in as needed. The following 
         </tr>
     </tbody>
 </table>
+
+## Static Conformance Requirements
+
+```
+The following is a model of a set of SCR tables.  
+DELETE THIS COMMENT
+```
+<table>
+    <caption>SCR for XYZ Component</caption>
+    <thead>
+        <tr>
+            <th>Item</th>
+            <th>Function</th>
+            <th>Reference</th>
+            <th>Requirement</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>XYZ-C-001-M</td>
+            <td>Something mandatory</td>
+            <td>Section x.y</td>
+            <td>(XYZ-C-004-O OR XYZ-C-003-M) AND
+                <br> &nbsp;XYZ-C-002-O</td>
+        </tr>
+        <tr>
+            <td>XYZ-C-002-O</td>
+            <td>Something optional</td>
+            <td>Section x.y</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>XYZ-C-003-M</td>
+            <td>Dependencies on ZYX</td>
+            <td>Section x.y</td>
+            <td>ZYX:MCF</td>
+        </tr>
+        <tr>
+            <td>XYZ-C-004-O</td>
+            <td>Dependencies on ZYX</td>
+            <td>Section x.y</td>
+            <td>ZYX:OCF</td>
+        </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
This PR is linked to the issue https://github.com/OpenManufacturingPlatform/rules_of_engagement/issues/23#issuecomment-636137365.

It suggests to add a new appendix section with a new table to represent Static Conformance Requirements as used in other standards development organizations.

Each technical requirement is collected in this table indicating: 
XYZ-{Component Type}-xxx-{Optional | Mandatory} where:
* XYZ: section reference
* Component Type: it could be "S": server, or "C": client or other
* xxx: sequence number
* "O": Optional
* "M": Mandatory

